### PR TITLE
Switched base image to Alpine. Removed 12 bit libx265 support.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-# Use Debian as a base image
-FROM debian:stable-slim
+# Use Alpine as a base image
+FROM alpine:latest
 
 # Set the working directory to /app
 WORKDIR /app
@@ -12,114 +12,110 @@ ADD . /app
 #--------------------------------
 RUN \
 export MAKEFLAGS="-j4" && \
-apt-get update && \
-apt-get install -y \
-  curl \
+apk --no-cache update && \
+apk --no-cache upgrade && \
+# Add build packages
+apk add --no-cache --update \
   autoconf \
   automake \
-  build-essential \
-  libass-dev \
-  libfreetype6-dev \
-  libsdl2-dev \
-  libtool \
-  libva-dev \
-  libvdpau-dev \
-  libvorbis-dev \
-  libxcb1-dev \
-  libxcb-shm0-dev \
-  libxcb-xfixes0-dev \
-  pkg-config \
-  texinfo \
-  zlib1g-dev \
-  git-core \
+  binutils \
+  bzip2-dev \
   cmake \
-  libnuma-dev \
-  libtool-bin \
+  file \
+  fortify-headers \
+  g++ \
+  gcc \
+  gmp \
+  isl \
+  libatomic \
+  libc-dev \
+  libgomp \
+  libmagic \
+  libtool \
+  make \
+  mpc1 \
+  mpfr3 \
+  musl-dev \
+  nasm \
   yasm && \
+# Add FFmpeg dependencies
+apk add --no-cache --update \
+  libgcc \
+  libstdc++ \
+  freetype-dev && \
+# Add system packages
+apk add --no-cache --update \
+  bash \
+  coreutils \
+  curl \
+  git && \
 #------------------
 # Setup directories
 #------------------
-mkdir -p /input /output /ffmpeg/ffmpeg_sources /ffmpeg/bin && \
-# Compile and install ffmpeg and ffprobe
+mkdir -p /input /output /ffmpeg/ffmpeg_sources && \
+#----------------
 # Download source
+#----------------
 cd /ffmpeg/ffmpeg_sources && \
-curl -O https://www.nasm.us/pub/nasm/releasebuilds/2.13.03/nasm-2.13.03.tar.bz2 && \
-tar xjf nasm-2.13.03.tar.bz2 && \
 git clone --depth 1 https://github.com/xiph/opus.git && \
 git clone --depth 1 https://git.videolan.org/git/x264 && \
 git clone https://github.com/videolan/x265.git && \
 curl -O https://ffmpeg.org/releases/ffmpeg-snapshot.tar.bz2 && \
 tar xjf ffmpeg-snapshot.tar.bz2 && \
-#-------------
-# Compile nasm
-#-------------
-cd /ffmpeg/ffmpeg_sources/nasm-2.13.03 && \
-./autogen.sh && \
-PATH="/ffmpeg/bin:$PATH" ./configure \
---prefix="/ffmpeg/ffmpeg_build" \
---bindir="/ffmpeg/bin" && \
-PATH="/ffmpeg/bin:$PATH" make ${MAKEFLAGS} && \
-make install && \
 #----------------
 # Compile libopus
 #----------------
 cd /ffmpeg/ffmpeg_sources/opus && \
 ./autogen.sh && \
 ./configure \
---prefix="/ffmpeg/ffmpeg_build" \
 --disable-shared && \
-PATH="/ffmpeg/bin:$PATH" make ${MAKEFLAGS} && \
+make ${MAKEFLAGS} && \
 make install && \
 #-------------
 # Compile x264
 #-------------
 cd /ffmpeg/ffmpeg_sources/x264 && \
-PATH="/ffmpeg/bin:$PATH" \
-PKG_CONFIG_PATH="/ffmpeg/ffmpeg_build/lib/pkgconfig" \
-./configure --prefix="/ffmpeg/ffmpeg_build" \
+./configure \
 --bindir="$HOME/bin" \
 --enable-static \
 --enable-pic && \
-PATH="/ffmpeg/bin:$PATH" make ${MAKEFLAGS} && \
+make ${MAKEFLAGS} && \
 make install && \
 #-------------
 # Compile x265
 #-------------
 cd /ffmpeg/ffmpeg_sources/x265/build/linux && \
 mkdir -p 8bit 10bit 12bit && \
+# 12 bit
 cd 12bit && \
-PATH="/ffmpeg/bin:$PATH" \
 cmake -G "Unix Makefiles" \
 ../../../source \
--DCMAKE_INSTALL_PREFIX="/ffmpeg/ffmpeg_build" \
 -DHIGH_BIT_DEPTH=ON \
 -DEXPORT_C_API=OFF \
 -DENABLE_SHARED=OFF \
 -DENABLE_CLI=OFF \
 -DMAIN12=ON && \
-PATH="/ffmpeg/bin:$PATH" make ${MAKEFLAGS} && \
+make ${MAKEFLAGS} && \
+# 10 bit
 cd ../10bit && \
-PATH="/ffmpeg/bin:$PATH" \
 cmake -G "Unix Makefiles" \
 ../../../source \
--DCMAKE_INSTALL_PREFIX="/ffmpeg/ffmpeg_build" \
 -DHIGH_BIT_DEPTH=ON \
 -DEXPORT_C_API=OFF \
 -DENABLE_SHARED=OFF \
 -DENABLE_CLI=OFF && \
-PATH="/ffmpeg/bin:$PATH" make ${MAKEFLAGS} && \
+make ${MAKEFLAGS} && \
+# 8 bit
 cd ../8bit && \
 ln -sf ../10bit/libx265.a libx265_main10.a && \
 ln -sf ../12bit/libx265.a libx265_main12.a && \
-PATH="/ffmpeg/bin:$PATH" \
 cmake -G "Unix Makefiles" \
 ../../../source \
--DCMAKE_INSTALL_PREFIX="/ffmpeg/ffmpeg_build" \
 -DEXTRA_LIB="x265_main10.a;x265_main12.a" \
 -DEXTRA_LINK_FLAGS=-L. \
 -DLINKED_10BIT=ON \
 -DLINKED_12BIT=ON && \
-PATH="/ffmpeg/bin:$PATH" make ${MAKEFLAGS} && \
+make ${MAKEFLAGS} && \
 mv libx265.a libx265_main.a && \
 ar -M </app/libx265.mri && \
 make install && \
@@ -127,17 +123,9 @@ make install && \
 # Compile ffmpeg
 #---------------
 cd /ffmpeg/ffmpeg_sources/ffmpeg && \
-PATH="/ffmpeg/bin:$PATH" \
-PKG_CONFIG_PATH="/ffmpeg/ffmpeg_build/lib/pkgconfig" \
 ./configure \
 --pkg-config-flags="--static" \
---prefix="/ffmpeg/ffmpeg_build" \
---extra-cflags="-I/ffmpeg/ffmpeg_build/include -static" \
---extra-ldflags="-L/ffmpeg/ffmpeg_build/lib -static" \
 --extra-libs="-lpthread -lm" \
---bindir="/ffmpeg/bin" \
---enable-static \
---disable-shared \
 --disable-debug \
 --disable-doc \
 --disable-ffplay \
@@ -147,43 +135,43 @@ PKG_CONFIG_PATH="/ffmpeg/ffmpeg_build/lib/pkgconfig" \
 --enable-libopus \
 --enable-libx264 \
 --enable-libx265 && \
-PATH="/ffmpeg/bin:$PATH" make ${MAKEFLAGS} && \
+make ${MAKEFLAGS} && \
 make install && \
 hash -r && \
-#-----------------------------------------
-# Copy ffmpeg and ffprobe to app directory
-#-----------------------------------------
-cp /ffmpeg/bin/ff* /app/ && \
 #----------------------------------------------------
 # Clean up directories and packages after compilation
 #----------------------------------------------------
 rm -rf /ffmpeg && \
-apt-get remove -y \
+# Remove build packages
+apk del \
   autoconf \
   automake \
-  build-essential \
-  libass-dev \
-  libfreetype6-dev \
-  libsdl2-dev \
-  libtool \
-  libva-dev \
-  libvdpau-dev \
-  libvorbis-dev \
-  libxcb1-dev \
-  libxcb-shm0-dev \
-  libxcb-xfixes0-dev \
-  pkg-config \
-  texinfo \
-  zlib1g-dev \
-  git-core \
+  binutils \
+  bzip2-dev \
   cmake \
-  libnuma-dev \
-  libtool-bin \
+  file \
+  fortify-headers \
+  g++ \
+  gcc \
+  gmp \
+  isl \
+  libatomic \
+  libc-dev \
+  libgomp \
+  libmagic \
+  libtool \
+  make \
+  mpc1 \
+  mpfr3 \
+  musl-dev \
+  nasm \
   yasm && \
-apt-get -y autoremove && \
-apt-get clean && \
-rm -rf /var/lib/apt/lists/*
+# Remove system packages
+apk del \
+  coreutils \
+  git && \
+rm -rf /var/cache/apk/*
 #---------------------------------------
 # Run ffmpeg when the container launches
 #---------------------------------------
-CMD ["/app/ffmpeg"]
+CMD ["ffmpeg"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -85,19 +85,9 @@ make install && \
 # Compile x265
 #-------------
 cd /ffmpeg/ffmpeg_sources/x265/build/linux && \
-mkdir -p 8bit 10bit 12bit && \
-# 12 bit
-cd 12bit && \
-cmake -G "Unix Makefiles" \
-../../../source \
--DHIGH_BIT_DEPTH=ON \
--DEXPORT_C_API=OFF \
--DENABLE_SHARED=OFF \
--DENABLE_CLI=OFF \
--DMAIN12=ON && \
-make ${MAKEFLAGS} && \
+mkdir -p 8bit 10bit && \
 # 10 bit
-cd ../10bit && \
+cd 10bit && \
 cmake -G "Unix Makefiles" \
 ../../../source \
 -DHIGH_BIT_DEPTH=ON \
@@ -108,13 +98,11 @@ make ${MAKEFLAGS} && \
 # 8 bit
 cd ../8bit && \
 ln -sf ../10bit/libx265.a libx265_main10.a && \
-ln -sf ../12bit/libx265.a libx265_main12.a && \
 cmake -G "Unix Makefiles" \
 ../../../source \
--DEXTRA_LIB="x265_main10.a;x265_main12.a" \
+-DEXTRA_LIB="x265_main10.a" \
 -DEXTRA_LINK_FLAGS=-L. \
--DLINKED_10BIT=ON \
--DLINKED_12BIT=ON && \
+-DLINKED_10BIT=ON && \
 make ${MAKEFLAGS} && \
 mv libx265.a libx265_main.a && \
 ar -M </app/libx265.mri && \

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ FFmpeg container compiled from git master HEAD with the following configuration:
 
 ```--pkg-config-flags=--static --extra-libs='-lpthread -lm' --disable-debug --disable-doc --disable-ffplay --enable-ffprobe --enable-gpl --enable-libfreetype --enable-libopus --enable-libx264 --enable-libx265```
 
-This is intended as a base image for five82\batchtranscode but can be run as a standalone container.
+This is intended as a base image for five82/batchtranscode but can be run as a standalone container.
 
 For example:
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 FFmpeg container compiled from git master HEAD with the following configuration:
 
-```--pkg-config-flags=--static --prefix=/ffmpeg/ffmpeg_build --extra-cflags='-I/ffmpeg/ffmpeg_build/include -static' --extra-ldflags='-L/ffmpeg/ffmpeg_build/lib -static' --extra-libs='-lpthread -lm' --bindir=/ffmpeg/bin --enable-static --disable-shared --disable-debug --disable-doc --disable-ffplay --enable-ffprobe --enable-gpl --enable-libfreetype --enable-libopus --enable-libx264 --enable-libx265```
+```--pkg-config-flags=--static --extra-libs='-lpthread -lm' --disable-debug --disable-doc --disable-ffplay --enable-ffprobe --enable-gpl --enable-libfreetype --enable-libopus --enable-libx264 --enable-libx265```
 
 This is intended as a base image for five82\batchtranscode but can be run as a standalone container.
 

--- a/libx265.mri
+++ b/libx265.mri
@@ -1,6 +1,5 @@
 create libx265.a
 addlib libx265_main.a
 addlib libx265_main10.a
-addlib libx265_main12.a
 save
 end


### PR DESCRIPTION
Switched base image to Alpine to reduce disk space. Switched ffmpeg from a static to dynamic binary for Alpine compatibility and to simplify the compilation. Removed libx265 12 bit support. five82/batchtranscode doesn't support 12 bit output and it reduces the size of the Docker image.